### PR TITLE
refactor: migrate CLI from cac to citty

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set node
         uses: actions/setup-node@v3
         with:
-          node-version: 22.22.1
+          node-version: latest
 
       - name: Setup
         run: npm i -g @antfu/ni
@@ -38,7 +38,7 @@ jobs:
       - name: Set node
         uses: actions/setup-node@v3
         with:
-          node-version: 22.22.1
+          node-version: latest
 
       - name: Setup
         run: npm i -g @antfu/ni
@@ -54,7 +54,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [22.22.1]
+        node: [latest]
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "packageManager": "pnpm@11.17.0",
   "engines": {
-    "node": ">=22.22.1"
+    "node": ">=24"
   },
   "description": "venti",
   "author": "LoTwT <709937065@qq.com>",
@@ -55,8 +55,8 @@
     "@types/node": "^26.1.1",
     "@types/prompts": "^2.4.9",
     "bumpp": "^12.0.0",
-    "cac": "^7.0.0",
     "chalk": "^5.6.2",
+    "citty": "^0.2.2",
     "envinfo": "^7.21.0",
     "execa": "^10.0.0",
     "lint-staged": "^17.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,12 +39,12 @@ importers:
       bumpp:
         specifier: ^12.0.0
         version: 12.0.0
-      cac:
-        specifier: ^7.0.0
-        version: 7.0.0
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
+      citty:
+        specifier: ^0.2.2
+        version: 0.2.2
       envinfo:
         specifier: ^7.21.0
         version: 7.21.0
@@ -1151,6 +1151,9 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -2392,6 +2395,8 @@ snapshots:
   chai@6.2.2: {}
 
   chalk@5.6.2: {}
+
+  citty@0.2.2: {}
 
   confbox@0.1.8: {}
 

--- a/src/bin/commands.ts
+++ b/src/bin/commands.ts
@@ -1,0 +1,129 @@
+import { parseArgs } from "node:util"
+
+import type { ArgType } from "citty"
+import { defineCommand, showUsage } from "citty"
+
+import { addAction, cloneAction, envAction, shellAction } from "@/utils"
+import pkgJson from "~/package.json"
+
+export const envCommand = defineCommand({
+  meta: {
+    name: "env",
+    description: "environment variables",
+  },
+  run() {
+    return envAction()
+  },
+})
+
+// options are derived from cloneCommand.args so this strict pre-parse stays
+// in sync with the real arg definitions (citty itself parses leniently)
+export function validateCloneArgs(rawArgs: string[]) {
+  const argsDef = cloneCommand.args as Record<
+    string,
+    { type?: ArgType; alias?: string | string[] }
+  >
+  const options: Record<
+    string,
+    { type: "string" | "boolean"; short?: string }
+  > = {}
+  let maxPositionals = 0
+
+  for (const [name, def] of Object.entries(argsDef)) {
+    if (def.type === "positional") {
+      maxPositionals += 1
+      continue
+    }
+    options[name] = { type: def.type === "boolean" ? "boolean" : "string" }
+    const [short] = [def.alias ?? []].flat()
+    if (short) options[name].short = short
+  }
+
+  const { positionals } = parseArgs({
+    args: rawArgs,
+    options,
+    allowPositionals: true,
+    strict: true,
+  })
+
+  if (positionals.length > maxPositionals) {
+    throw new TypeError(
+      `Unexpected positional argument: ${positionals[maxPositionals]}`,
+    )
+  }
+}
+
+export const cloneCommand = defineCommand({
+  meta: {
+    name: "clone",
+    description: "wrapper of git clone",
+  },
+  args: {
+    repo: {
+      type: "positional",
+      description: "repository in user/repo format",
+      required: true,
+    },
+    dirname: {
+      type: "positional",
+      description: "target directory name",
+      required: false,
+    },
+    platform: {
+      type: "enum",
+      description: "github or gitlab",
+      options: ["github", "gitlab"],
+      alias: "p",
+    },
+    clean: {
+      type: "boolean",
+      description: "clean clone without .git",
+      alias: "c",
+    },
+  },
+  run({ args }) {
+    return cloneAction(args.repo, args.dirname, {
+      platform: args.platform,
+      clean: args.clean,
+    })
+  },
+})
+
+export const addCommand = defineCommand({
+  meta: {
+    name: "add",
+    description: "add dependencies",
+  },
+  run() {
+    return addAction()
+  },
+})
+
+export const shellCommand = defineCommand({
+  meta: {
+    name: "shell",
+    description: "run shell update",
+  },
+  run() {
+    return shellAction()
+  },
+})
+
+export const mainCommand = defineCommand({
+  meta: {
+    name: "venti",
+    version: pkgJson.version,
+    description: pkgJson.description,
+  },
+  subCommands: {
+    env: envCommand,
+    clone: cloneCommand,
+    add: addCommand,
+    shell: shellCommand,
+  },
+  // citty runs the parent's `run` even after dispatching to a subcommand,
+  // so only show usage when no subcommand was given
+  run({ cmd, rawArgs }) {
+    if (rawArgs.length === 0) return showUsage(cmd)
+  },
+})

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,24 +1,20 @@
-import createCac from "cac"
+import { runMain } from "citty"
 
-import { addAction, cloneAction, envAction, shellAction } from "@/utils"
-import pkgJson from "~/package.json"
+import { mainCommand, validateCloneArgs } from "./commands"
 
-const cac = createCac("venti")
+const [command, ...commandArgs] = process.argv.slice(2)
 
-cac.command("env", "environment variables").action(envAction)
+if (
+  command === "clone" &&
+  !commandArgs.includes("--help") &&
+  !commandArgs.includes("-h")
+) {
+  try {
+    validateCloneArgs(commandArgs)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  }
+}
 
-cac
-  .command("clone <repo> [dirname]", "wrapper of git clone")
-  .option("-p, --platform [platform]", "github or gitlab")
-  .option("-c, --clean", "clean clone without .git")
-  .action(cloneAction)
-
-cac.command("add", "add dependencies").action(addAction)
-
-cac.command("shell", "run shell update").action(shellAction)
-
-cac.help()
-
-cac.version(pkgJson.version)
-
-cac.parse()
+if (process.exitCode !== 1) await runMain(mainCommand)

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -37,13 +37,15 @@ ${npmPackages.reduce(
   },
 }
 
-async function getPackageManager() {
+export async function getPackageManager() {
   const packageJsonPath = path.resolve(process.cwd(), "package.json")
 
   let packageManager: Nullable<string> = null
 
   if (fs.existsSync(packageJsonPath))
-    packageManager = (await import(packageJsonPath))?.packageManager ?? null
+    packageManager =
+      JSON.parse(await fs.promises.readFile(packageJsonPath, "utf8"))
+        ?.packageManager ?? null
 
   return packageManager
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
 export { addAction, copyTemplate, getPackageManagerCommand } from "./add"
 export { cloneAction } from "./clone"
-export { envAction } from "./env"
+export { envAction, getPackageManager } from "./env"
 export { shellAction } from "./shell"

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,84 @@
+import { runCommand } from "citty"
+import { vi } from "vitest"
+
+import { cloneCommand, mainCommand, validateCloneArgs } from "@/bin/commands"
+
+describe("CLI argument validation", () => {
+  it("accepts supported clone arguments", () => {
+    expect(() => validateCloneArgs(["user/repo"])).not.toThrow()
+    expect(() =>
+      validateCloneArgs([
+        "user/repo",
+        "target",
+        "--platform",
+        "gitlab",
+        "--clean",
+      ]),
+    ).not.toThrow()
+  })
+
+  it("maps parsed clone arguments to the action adapter", async () => {
+    const originalRun = cloneCommand.run
+    const run = vi.fn<(args: unknown) => void>()
+
+    try {
+      run.mockImplementation(() => undefined)
+      cloneCommand.run = ({ args }) => run(args)
+
+      await runCommand(mainCommand, {
+        rawArgs: [
+          "clone",
+          "user/repo",
+          "target",
+          "--platform",
+          "gitlab",
+          "--clean",
+        ],
+      })
+
+      expect(run).toHaveBeenCalledWith(
+        expect.objectContaining({
+          repo: "user/repo",
+          dirname: "target",
+          platform: "gitlab",
+          clean: true,
+        }),
+      )
+    } finally {
+      cloneCommand.run = originalRun
+    }
+  })
+
+  it("shows usage only when no subcommand is given", async () => {
+    const originalRun = cloneCommand.run
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined)
+
+    try {
+      cloneCommand.run = () => undefined
+
+      await runCommand(mainCommand, { rawArgs: ["clone", "user/repo"] })
+      expect(log).not.toHaveBeenCalled()
+
+      await runCommand(mainCommand, { rawArgs: [] })
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("USAGE"))
+    } finally {
+      cloneCommand.run = originalRun
+      log.mockRestore()
+    }
+  })
+
+  it("rejects unknown clone options", () => {
+    expect(() => validateCloneArgs(["user/repo", "--cleen"])).toThrow(
+      /Unknown option/,
+    )
+    expect(() =>
+      validateCloneArgs(["user/repo", "--platfrom", "gitlab"]),
+    ).toThrow(/Unknown option/)
+  })
+
+  it("rejects extra clone positional arguments", () => {
+    expect(() => validateCloneArgs(["user/repo", "target", "extra"])).toThrow(
+      "Unexpected positional argument: extra",
+    )
+  })
+})

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,0 +1,37 @@
+import { mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import process from "node:process"
+
+import { vi } from "vitest"
+
+import { getPackageManager } from "@/utils"
+
+describe("getPackageManager", () => {
+  it("reads the packageManager field from the cwd package.json", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "venti-env-"))
+    await writeFile(
+      join(dir, "package.json"),
+      '{"packageManager":"pnpm@11.17.0"}',
+    )
+
+    const cwd = vi.spyOn(process, "cwd").mockReturnValue(dir)
+
+    try {
+      await expect(getPackageManager()).resolves.toBe("pnpm@11.17.0")
+    } finally {
+      cwd.mockRestore()
+    }
+  })
+
+  it("returns null when no package.json exists", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "venti-env-"))
+    const cwd = vi.spyOn(process, "cwd").mockReturnValue(dir)
+
+    try {
+      await expect(getPackageManager()).resolves.toBeNull()
+    } finally {
+      cwd.mockRestore()
+    }
+  })
+})

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -8,7 +8,6 @@ import { defineConfig } from "tsdown"
 export default defineConfig({
   entry: ["./src/bin/index.ts"],
   format: ["esm"],
-  target: "node22.22.1",
   clean: true,
   dts: false,
   outDir: "dist/bin",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   ],
   test: {
     includeSource: ["src/*"],
+    include: ["test/**/*.test.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- migrate CLI framework from cac to citty, with strict clone argument validation derived from the command definition
- fix env command reading package.json with fs instead of dynamic import (crashed with ERR_IMPORT_ATTRIBUTE_MISSING on recent Node)
- scope vitest includes to the test directory
- require Node.js >=24; tsdown build target is now derived from package.json engines
- run CI against latest Node

## Test plan

- [x] pnpm vitest run (12/12)
- [x] pnpm typecheck / lint / format:check
- [x] built CLI smoke: bare venti usage, clone validation paths, venti env, --version