### PR TITLE
docs: add project documentation and agent setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Agent 工作指南
+
+项目文档主要使用中文，必要时使用英文。
+
+- **渐进式披露**：需要了解项目文档时，以 `docs/index.md` 为统一入口，仅按当前任务需要查阅相关内容。
+- **单一事实来源**：同一项知识应由一个明确的权威来源维护，其他位置通过引用使用，避免重复定义。
+- **指令作用域与优先级**：遵循当前修改范围内最具体的适用规则，无法消解的指令冲突应在执行前明确指出。
+- **先理解，后修改**：修改前先理解相关代码、测试、配置和既有约定，不根据名称或表象猜测行为。
+- **语义明确**：代码应通过准确的命名、类型、接口和结构直接表达业务意图；准确性优先于简短，允许使用更长的函数名、类名和变量名，避免含糊缩写、泛化命名及依赖注释补充核心语义。
+- **最小充分变更**：实施能够完整满足要求的最小连贯变更，不进行无关的重构、清理或格式化。
+- **基于证据的验证与报告**：通过实际检查验证结果，只报告已确认的事实，并明确说明失败、跳过和未验证事项。
+
+## 项目概览
+
+venti 是一个个人 CLI 工具集（`@ayingott/venti`，bin 为 `venti`），面向交互式与非交互式（agent/脚本）两种用法，要求 Node.js >= 24。当前包含三个子命令：`clone`、`upgrade`、`doctor`。命令用法以 `README.md` 为单一事实来源，项目文档见 `docs/index.md`。
+
+## 技术栈与约定
+
+- TypeScript ESM，包管理器 pnpm，构建工具 tsdown（产物为 `dist/bin/index.mjs`）。
+- CLI 框架 citty，子命令定义集中在 `src/bin/commands.ts`。
+- 路径别名：`@/*` → `src/*`，`~/*` → 项目根（`tsconfig.json`、`vitest.config.ts`、`tsdown.config.ts` 三处保持同步）。
+- 测试用 vitest，测试文件放在 `test/` 目录，通过 unplugin-auto-import 自动导入 vitest API（`describe`/`it`/`expect` 无需显式导入）。
+- Lint 用 oxlint，格式化用 oxfmt；pre-commit 钩子（simple-git-hooks + lint-staged）会自动执行。
+
+## 常用命令
+
+- 开发调试：`pnpm build && pnpm cli <args>`（`src/bin/cli.js` 是对构建产物的引用）
+- 测试：`pnpm test`（单次运行用 `pnpm test run`）
+- 类型检查：`pnpm typecheck`
+- Lint / 格式化：`pnpm lint` / `pnpm format`
+- 发布：`pnpm release`（bumpp 升级版本后 npm publish）
+
+## 验证要求
+
+修改代码后，至少运行与改动相关的测试和 `pnpm typecheck`；涉及 CLI 参数的行为变更需覆盖 `test/cli.test.ts` 中的参数校验。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,1 +1,69 @@
 # venti
+
+A personal CLI toolkit, designed for both interactive and non-interactive (agent/script) usage.
+
+Requires Node.js >= 24.
+
+## Install
+
+```bash
+npm install -g @ayingott/venti
+```
+
+## Usage
+
+```bash
+venti <command> [options]
+```
+
+Running `venti` with no command prints the usage.
+
+### `venti clone <repo> [dirname]`
+
+A wrapper of `git clone`.
+
+- `<repo>` — repository in `user/repo` format, or a full https/ssh URL (passed through untouched)
+- `[dirname]` — target directory name, defaults to the repository name
+- `-p, --platform <github|gitlab>` — platform prefix for `user/repo` shorthand (default: `github`)
+- `-c, --clean` — remove the `.git` directory after cloning
+- `-d, --depth <depth>` — create a shallow clone with the given depth
+
+```bash
+venti clone LoTwT/venti
+venti clone LoTwT/venti my-dir --clean --depth 1
+venti clone https://github.com/LoTwT/venti.git
+```
+
+### `venti upgrade [names]`
+
+Run tool upgrades for a known set of tools: `pnpm`, `brew`, `claude`, `kimi`, `rust`, `bun`. Tools that are not installed are skipped.
+
+- `[names]` — comma-separated tool names, e.g. `brew,rust`
+- `--all` — upgrade all known tools
+- `-y, --yes` — run without confirmation (required for non-interactive runs)
+- `--dry-run` — print the commands without running them
+- `--json` — machine-readable JSON output
+
+With no selection, an interactive multi-select prompt is shown in a TTY; in non-TTY contexts (or with `--json`) the available tools are listed instead.
+
+```bash
+venti upgrade                # interactive multi-select
+venti upgrade brew,rust -y
+venti upgrade --all --yes --json
+venti upgrade --all --dry-run
+```
+
+### `venti doctor`
+
+Check the local environment: Node.js version, git, the package manager declared in `package.json`, and the availability of the upgrade tools. Exits with code 1 when any check fails.
+
+- `--json` — machine-readable JSON output
+
+```bash
+venti doctor
+venti doctor --json
+```
+
+## License
+
+[MIT](./LICENSE)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,42 @@
+# 架构说明
+
+## 目录结构
+
+```
+src/
+  bin/
+    index.ts      # CLI 入口：严格预校验后 runMain(mainCommand)
+    commands.ts   # citty 命令定义与参数校验
+    cli.js        # 开发调试用，引用构建产物 dist/bin/index.mjs
+  utils/
+    clone.ts      # clone 命令的实现
+    upgrade.ts    # upgrade 命令的实现（工具清单 upgradeEntries 在此维护）
+    doctor.ts     # doctor 命令的实现
+    index.ts      # utils 的统一导出
+test/             # vitest 测试，与 src/utils 一一对应，另有 cli.test.ts 覆盖参数层
+```
+
+构建入口是 `src/bin/index.ts`，tsdown 产出单文件 ESM `dist/bin/index.mjs`（带 `#!/usr/bin/env node` banner），即 `package.json` 的 `bin.venti`。`src/index.ts` 为空文件，仅占位。
+
+## 命令注册与参数校验
+
+- 三个子命令（`clone`、`upgrade`、`doctor`）用 citty 的 `defineCommand` 定义在 `src/bin/commands.ts`，挂载到 `mainCommand.subCommands`；`mainCommand.run` 仅在无子命令时打印 usage。
+- citty 解析参数较宽松，因此 `src/bin/index.ts` 在 `runMain` 之前用 `validateCommandArgs`（基于 `node:util` 的 `parseArgs`，strict 模式）对子命令参数做一次严格预校验：未知选项、多余的 positional 参数会直接报错并以退出码 1 结束。校验规则从命令的 `args` 定义派生，包括 camelCase 到 kebab-case 的自动别名，新增/修改参数时无需额外同步。
+- 每个命令的 `run` 只是把解析后的 args 适配给 `src/utils/` 里对应的 action，业务逻辑全部在 utils 层，便于脱离 CLI 直接测试。
+
+## 非交互设计
+
+CLI 同时服务人类（TTY）与 agent/脚本（非 TTY），行为分支约定：
+
+- `clone`：仓库名非法时，TTY 下进入交互式修补提示，非 TTY 下直接报错退出。
+- `upgrade`：未指定工具时，TTY 下弹出多选交互，非 TTY 或 `--json` 时列出可用工具后退出；显式指定工具的运行必须带 `--yes` 确认；`--dry-run` 只打印计划。未安装的工具标记为 `skipped`。
+- `doctor`：`--json` 输出机器可读结果；任何检查失败时退出码为 1。
+- `--json` 模式下子进程的 stdout 会被接管（pipe），保证 JSON 输出可解析。
+
+新增命令或选项时应保持这一约定：非 TTY 环境不得阻塞在交互提示上。
+
+## 测试分布
+
+- `test/cli.test.ts`：参数校验与 args 到 action 的映射（用 citty 的 `runCommand` 驱动）。
+- `test/clone.test.ts` / `upgrade.test.ts` / `doctor.test.ts`：对应 utils 的纯函数与行为（URL 解析、工具名解析、检查评估等）。
+- `test/index.test.ts`：utils 导出面。

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,36 @@
+# 开发指南
+
+## 环境要求
+
+- Node.js >= 24（`package.json` 的 `engines`，构建 target 也由此推导）
+- pnpm 11.17.0（`packageManager` 字段锁定）
+
+```bash
+pnpm install
+```
+
+## 常用脚本
+
+| 命令                                | 说明                                                       |
+| ----------------------------------- | ---------------------------------------------------------- |
+| `pnpm build`                        | tsdown 构建到 `dist/bin/`                                  |
+| `pnpm cli <args>`                   | 运行构建产物（等价于 `node ./src/bin/cli.js`），需先 build |
+| `pnpm test`                         | vitest（watch 模式）；CI/单次运行用 `pnpm test run`        |
+| `pnpm typecheck`                    | `tsc --noEmit`                                             |
+| `pnpm lint` / `pnpm lint:fix`       | oxlint 检查 / 自动修复（`--deny-warnings`）                |
+| `pnpm format` / `pnpm format:check` | oxfmt 格式化 / 检查                                        |
+| `pnpm play`                         | 在 `playground/` 中运行 venti                              |
+| `pnpm release`                      | bumpp 升级版本并 `npm publish --access public`             |
+
+提交前 simple-git-hooks 会通过 lint-staged 对暂存文件执行 `oxlint --fix` 和 `oxfmt --write`。
+
+## 修改 checklist
+
+1. 改完代码后运行 `pnpm test run` 和 `pnpm typecheck`，必要时加 `pnpm lint`。
+2. 行为变更需同步测试：CLI 参数层看 `test/cli.test.ts`，utils 逻辑看对应的 `test/*.test.ts`。
+3. 命令用法变更需同步 `README.md`（用法说明的单一事实来源）；结构或流程变更需同步 `docs/architecture.md` / 本文档。
+4. 新增路径别名时，`tsconfig.json`、`vitest.config.ts`、`tsdown.config.ts` 三处都要改。
+
+## 发布流程
+
+`pnpm release` 使用 bumpp 交互式选择版本号，随后构建并发布到 npm（`prepack`/`prepublishOnly` 会自动再构建一次）。

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# 文档索引
+
+项目文档的统一入口，按任务需要查阅。
+
+## 使用文档
+
+- [README.md](../README.md)：安装与三个子命令（`clone`、`upgrade`、`doctor`）的完整用法说明，是命令用法的单一事实来源。
+
+## 开发文档
+
+- [architecture.md](./architecture.md)：目录结构、CLI 命令注册与严格参数预校验、非交互设计、测试分布。
+- [development.md](./development.md)：环境要求、常用脚本、测试与检查、发布流程。
+
+## Agent 配置
+
+- [AGENTS.md](../AGENTS.md)：Agent 工作指南（通用原则 + 项目概览、技术栈与验证要求）。
+- [CLAUDE.md](../CLAUDE.md)：引用 `AGENTS.md`，保持一致。


### PR DESCRIPTION
## Summary

- Rewrite `README.md` with full usage for the reworked CLI (`clone`, `upgrade`, `doctor`), reflecting the non-interactive design from #3
- Add `AGENTS.md` (working guide + project overview, stack, commands, verification requirements) and `CLAUDE.md` referencing it
- Add `docs/index.md` as the documentation entry point
- Add `docs/architecture.md`: directory layout, citty command registration and strict arg pre-validation, TTY/non-TTY behavior contract, test layout
- Add `docs/development.md`: environment requirements, scripts, change checklist, release process

Command usage stays in `README.md` as the single source of truth; `docs/` references it instead of duplicating.

Agent-Tool: Kimi Code CLI