### PR TITLE
fix: disable pnpm minimum release age during upgrade

### DIFF
--- a/src/utils/upgrade.ts
+++ b/src/utils/upgrade.ts
@@ -26,7 +26,10 @@ export interface UpgradeOptions {
 }
 
 export const upgradeEntries: UpgradeEntry[] = [
-  { name: "pnpm", command: "pnpm update -gL" },
+  {
+    name: "pnpm",
+    command: "pnpm update -gL --config.minimum-release-age=0",
+  },
   { name: "brew", command: "brew upgrade" },
   { name: "claude", command: "claude install" },
   { name: "kimi", command: "kimi upgrade" },

--- a/test/upgrade.test.ts
+++ b/test/upgrade.test.ts
@@ -29,6 +29,14 @@ describe("parseNames", () => {
   })
 })
 
+describe("upgrade entries", () => {
+  it("disables the minimum release age for pnpm updates", () => {
+    expect(upgradeEntries.find((entry) => entry.name === "pnpm")?.command).toBe(
+      "pnpm update -gL --config.minimum-release-age=0",
+    )
+  })
+})
+
 describe("resolveTargets", () => {
   it("resolves known names in registry order", () => {
     const { targets, invalid } = resolveTargets(upgradeEntries, ["bun", "brew"])


### PR DESCRIPTION
## Summary

- pass `--config.minimum-release-age=0` to the pnpm global update command
- add regression coverage for the pnpm upgrade entry

## Verification

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test run`
- `pnpm build`
- isolated install smoke from `pnpm pack`